### PR TITLE
[LPS-003] Optimizing for large log files

### DIFF
--- a/pkg/logreader_benchmark_test.go
+++ b/pkg/logreader_benchmark_test.go
@@ -70,28 +70,48 @@ func generateLargeLog(filePath string, targetSizeMB int) error {
 var table = []struct {
 	SizeInMB int
 }{
-	{SizeInMB: 10},   // 10MB
-	{SizeInMB: 100},  // 100MB
-	{SizeInMB: 200},  // 200MB
-	{SizeInMB: 500},  // 500MB
+	// {SizeInMB: 10},   // 10MB
+	// {SizeInMB: 100},  // 100MB
+	// {SizeInMB: 200},  // 200MB
+	// {SizeInMB: 500},  // 500MB
 	{SizeInMB: 1000}, // 1GB
-	{SizeInMB: 2000}, // 2GB
-	{SizeInMB: 5000}, // 5GB
+	// {SizeInMB: 2000}, // 2GB
+	// {SizeInMB: 5000}, // 5GB
 }
 
 // Benchmark for ReadLastNLines with a large log file
-func Benchmark_ReadLastNLines(b *testing.B) {
+// func Benchmark_ReadLastNLines(b *testing.B) {
+// 	for _, v := range table {
+// 		b.Run(fmt.Sprintf("input_size_%d", v.SizeInMB), func(b *testing.B) {
+// 			logFilePath := "large_access.log"
+// 			err := generateLargeLog(logFilePath, v.SizeInMB)
+// 			if err != nil {
+// 				b.Fatalf("Failed to generate log file: %v", err)
+// 			}
+
+// 			b.ResetTimer()
+// 			for n := 0; n < b.N; n++ {
+// 				_, err := ReadLastNLines(logFilePath, 1000, "services.html")
+// 				if err != nil {
+// 					b.Fatalf("Failed to read last N lines: %v", err)
+// 				}
+// 			}
+// 		})
+// 	}
+// }
+
+func Benchmark_ReadLastNLines_NotFound(b *testing.B) {
 	for _, v := range table {
 		b.Run(fmt.Sprintf("input_size_%d", v.SizeInMB), func(b *testing.B) {
 			logFilePath := "large_access.log"
-			err := generateLargeLog(logFilePath, targetSizeMB)
+			err := generateLargeLog(logFilePath, v.SizeInMB)
 			if err != nil {
 				b.Fatalf("Failed to generate log file: %v", err)
 			}
 
 			b.ResetTimer()
 			for n := 0; n < b.N; n++ {
-				_, err := ReadLastNLines(logFilePath, 1000, "services.html")
+				_, err := ReadLastNLines(logFilePath, 1000, "iddqd")
 				if err != nil {
 					b.Fatalf("Failed to read last N lines: %v", err)
 				}

--- a/pkg/logreader_benchmark_test.go
+++ b/pkg/logreader_benchmark_test.go
@@ -103,12 +103,13 @@ var table = []struct {
 func Benchmark_ReadLastNLines_NotFound(b *testing.B) {
 	for _, v := range table {
 		b.Run(fmt.Sprintf("input_size_%d", v.SizeInMB), func(b *testing.B) {
+			fmt.Println("Start generating large log file...")
 			logFilePath := "large_access.log"
 			err := generateLargeLog(logFilePath, v.SizeInMB)
 			if err != nil {
 				b.Fatalf("Failed to generate log file: %v", err)
 			}
-
+			fmt.Println("Start benchmarking...")
 			b.ResetTimer()
 			for n := 0; n < b.N; n++ {
 				_, err := ReadLastNLines(logFilePath, 1000, "iddqd")

--- a/pkg/logreader_benchmark_test.go
+++ b/pkg/logreader_benchmark_test.go
@@ -100,13 +100,11 @@ func Benchmark_ReadLastNLines(b *testing.B) {
 func Benchmark_ReadLastNLines_NotFound(b *testing.B) {
 	for _, v := range table {
 		b.Run(fmt.Sprintf("input_size_%d", v.SizeInMB), func(b *testing.B) {
-			fmt.Println("Start generating large log file...")
 			logFilePath := "large_access.log"
 			err := generateLargeLog(logFilePath, v.SizeInMB)
 			if err != nil {
 				b.Fatalf("Failed to generate log file: %v", err)
 			}
-			fmt.Println("Start benchmarking...")
 			for n := 0; n < b.N; n++ {
 				b.StartTimer()
 				_, err := ReadLastNLines(logFilePath, 1000, "iddqd")

--- a/pkg/logreader_benchmark_test.go
+++ b/pkg/logreader_benchmark_test.go
@@ -8,8 +8,6 @@ import (
 	"time"
 )
 
-const targetSizeMB = 20
-
 // Randomization functions
 func randomIP() string {
 	return fmt.Sprintf("%d.%d.%d.%d", rand.Intn(256), rand.Intn(256), rand.Intn(256), rand.Intn(256))
@@ -70,35 +68,34 @@ func generateLargeLog(filePath string, targetSizeMB int) error {
 var table = []struct {
 	SizeInMB int
 }{
-	// {SizeInMB: 10},   // 10MB
-	// {SizeInMB: 100},  // 100MB
-	// {SizeInMB: 200},  // 200MB
-	// {SizeInMB: 500},  // 500MB
+	{SizeInMB: 10},   // 10MB
+	{SizeInMB: 100},  // 100MB
+	{SizeInMB: 200},  // 200MB
+	{SizeInMB: 500},  // 500MB
 	{SizeInMB: 1000}, // 1GB
-	// {SizeInMB: 2000}, // 2GB
-	// {SizeInMB: 5000}, // 5GB
+	{SizeInMB: 2000}, // 2GB
 }
 
 // Benchmark for ReadLastNLines with a large log file
-// func Benchmark_ReadLastNLines(b *testing.B) {
-// 	for _, v := range table {
-// 		b.Run(fmt.Sprintf("input_size_%d", v.SizeInMB), func(b *testing.B) {
-// 			logFilePath := "large_access.log"
-// 			err := generateLargeLog(logFilePath, v.SizeInMB)
-// 			if err != nil {
-// 				b.Fatalf("Failed to generate log file: %v", err)
-// 			}
-
-// 			b.ResetTimer()
-// 			for n := 0; n < b.N; n++ {
-// 				_, err := ReadLastNLines(logFilePath, 1000, "services.html")
-// 				if err != nil {
-// 					b.Fatalf("Failed to read last N lines: %v", err)
-// 				}
-// 			}
-// 		})
-// 	}
-// }
+func Benchmark_ReadLastNLines(b *testing.B) {
+	for _, v := range table {
+		b.Run(fmt.Sprintf("input_size_%d", v.SizeInMB), func(b *testing.B) {
+			logFilePath := "large_access.log"
+			err := generateLargeLog(logFilePath, v.SizeInMB)
+			if err != nil {
+				b.Fatalf("Failed to generate log file: %v", err)
+			}
+			for n := 0; n < b.N; n++ {
+				b.StartTimer()
+				_, err := ReadLastNLines(logFilePath, 1000, "services.html")
+				if err != nil {
+					b.Fatalf("Failed to read last N lines: %v", err)
+				}
+				b.StopTimer()
+			}
+		})
+	}
+}
 
 func Benchmark_ReadLastNLines_NotFound(b *testing.B) {
 	for _, v := range table {
@@ -110,12 +107,13 @@ func Benchmark_ReadLastNLines_NotFound(b *testing.B) {
 				b.Fatalf("Failed to generate log file: %v", err)
 			}
 			fmt.Println("Start benchmarking...")
-			b.ResetTimer()
 			for n := 0; n < b.N; n++ {
+				b.StartTimer()
 				_, err := ReadLastNLines(logFilePath, 1000, "iddqd")
 				if err != nil {
 					b.Fatalf("Failed to read last N lines: %v", err)
 				}
+				b.StopTimer()
 			}
 		})
 	}

--- a/pkg/logreader_test.go
+++ b/pkg/logreader_test.go
@@ -1,3 +1,5 @@
+//go:build unit
+
 package pkg
 
 import (

--- a/pkg/logreader_test.go
+++ b/pkg/logreader_test.go
@@ -1,5 +1,3 @@
-//go:build unit
-
 package pkg
 
 import (
@@ -61,15 +59,18 @@ line12`
 		lines, err := ReadLastNLines(tmpfile.Name(), test.n, test.filter)
 		if err != nil {
 			t.Errorf("Failed to read last %d lines: %v", test.n, err)
+			t.FailNow()
 		}
 
 		if len(lines) != len(test.expected) {
 			t.Errorf("Expected %d lines, got %d lines", len(test.expected), len(lines))
+			t.FailNow()
 		}
 
 		for i := range lines {
 			if lines[i] != test.expected[i] {
 				t.Errorf("Expected line %q, got %q", test.expected[i], lines[i])
+				t.FailNow()
 			}
 		}
 	}


### PR DESCRIPTION
- Reading by pages, not by chars to improve performancce
- Page size is 64KB as a sweet spot for now
- Using multi-threading to produce the chunk and consume it concurrently
- Considering edge case when a string is split between two pages, hence reading an extra chars to consider it
https://github.com/NguyenIconAI/logspullerservice/issues/2